### PR TITLE
Remove must_include logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: build-test
 
 on:
   pull_request:
+    types:
+    - synchronize
+    - opened
+    - reopened
+    - ready_for_review
   push:
 
 jobs:
@@ -9,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
     - run: |
         # set default git config for unit tests
         git config --global user.email "gha@ci"

--- a/README.md
+++ b/README.md
@@ -2,19 +2,21 @@
 
 ![build-test](https://github.com/lostick/conditional-diffing-action/workflows/build-test/badge.svg?branch=master)
 
-This action can be used in a job step to filter paths based on rules that produce a git diff output. The action's output can be used to conditionally run subsequent steps.
+This action can be used in a job step to filter paths based on git diff rules.  
+The step sets `DIFF_DETECTED` environment variable as true or false, which can then be reused to conditionally run subsequent steps.
 
 ## Usage
 
 ```yaml
-runs-on: ubuntu-latest
 steps:
+# Make sure to fetch all branches in order to do run git diff
 - uses: actions/checkout@v2
 - run: git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
+
 - uses: lostick/conditional-diffing-action@v0.1.0
+
+# This step uses DIFF_DETECTED env var to determine whether it needs to be run or not
 - name: Setup go
   if: env.DIFF_DETECTED
-  uses: actions/setup-go@v1
-  with:
-    go-version: '1.14.0-rc1'
+  uses: actions/setup-go@v2
 ```

--- a/__tests__/finder.test.ts
+++ b/__tests__/finder.test.ts
@@ -61,43 +61,6 @@ describe('test diffing rules', () => {
     expect(matches).toBeTruthy()
   })
 
-  test('match diff change on parent dir with must include condition', async () => {
-    let rule = {
-      paths: ['__tests__/fixtures/dummy3'],
-      must_include: ['__tests__/fixtures/dummy3/envs/preprod']
-    }
-    const diff = await finder.getDiff(finder.buildOptions(rule))
-    const fillFiles = diff.files.map(elem => elem.file)
-    expect(fillFiles).toContainEqual('__tests__/fixtures/dummy3/test')
-    expect(diff.changed).toBe(2)
-    expect(diff.insertions).toBe(1)
-
-    const satisfiesMustInclude = finder.satisfiesMustInclude(rule)
-    expect(satisfiesMustInclude).toBeTruthy()
-
-    const match = await finder.ruleMatchesChange(rule)
-    expect(match).toBeTruthy()
-  })
-
-  test('no diff change on parent dir with must include condition', async () => {
-    let rule = {
-      paths: ['__tests__/fixtures/dummy3'],
-      must_include: ['__tests__/fixtures/dummy3/envs/staging']
-    }
-
-    const diff = await finder.getDiff(finder.buildOptions(rule))
-    const fillFiles = diff.files.map(elem => elem.file)
-    expect(fillFiles).toContainEqual('__tests__/fixtures/dummy3/test')
-    expect(diff.changed).toBe(2)
-    expect(diff.insertions).toBe(1)
-
-    const satisfiesMustInclude = finder.satisfiesMustInclude(rule)
-    expect(satisfiesMustInclude).not.toBeTruthy()
-
-    const match = await finder.ruleMatchesChange(rule)
-    expect(match).not.toBeTruthy()
-  })
-
   test('no diff change on unknown parent dir', async () => {
     let rule = {
       paths: ['__tests__/fixtures/dummy-does-not-exist']
@@ -120,26 +83,6 @@ describe('test diffing yaml manifests', () => {
     for (const rule of rules) {
       let match = await finder.ruleMatchesChange(rule)
       expect(match).toBeTruthy()
-    }
-  })
-
-  test('match diff change on parent dir with must include condition', async () => {
-    const file = '__tests__/rules-test2.yml'
-    const rules = await helpers.getYamlRules(file)
-
-    for (const rule of rules) {
-      let match = await finder.ruleMatchesChange(rule)
-      expect(match).toBeTruthy()
-    }
-  })
-
-  test('no diff change on parent dir with must include condition', async () => {
-    const file = '__tests__/rules-test3.yml'
-    const rules = await helpers.getYamlRules(file)
-
-    for (const rule of rules) {
-      let match = await finder.ruleMatchesChange(rule)
-      expect(match).not.toBeTruthy()
     }
   })
 })

--- a/__tests__/rules-test2.yml
+++ b/__tests__/rules-test2.yml
@@ -1,5 +1,3 @@
 rules:
 - paths:
   - __tests__/fixtures/dummy3
-  must_include:
-  - __tests__/fixtures/dummy3/envs/preprod

--- a/__tests__/rules-test3.yml
+++ b/__tests__/rules-test3.yml
@@ -1,5 +1,3 @@
 rules:
 - paths:
   - __tests__/fixtures/dummy4
-  must_include:
-  - __tests__/fixtures/dummy4/envs/staging

--- a/dist/index.js
+++ b/dist/index.js
@@ -3590,7 +3590,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const fs_1 = __importDefault(__webpack_require__(747));
 const promise_1 = __importDefault(__webpack_require__(57));
 const helpers_1 = __webpack_require__(441);
 exports.ROOT_DIR = helpers_1.getRootDir();
@@ -3601,7 +3600,7 @@ function ruleMatchesChange(rule) {
         const options = buildOptions(rule);
         const diff = yield getDiff(options);
         core.debug(`Diffing with options ${options}`);
-        if (diff.changed > 0 && satisfiesMustInclude(rule)) {
+        if (diff.changed > 0) {
             const diffedFiles = diff.files.map(elem => elem.file);
             core.info(`Changed files: ${diffedFiles}`);
             return true;
@@ -3625,21 +3624,6 @@ function buildOptions(rule) {
     return fullPaths.length ? ['--', ...fullPaths] : [];
 }
 exports.buildOptions = buildOptions;
-/** Processes must_include in the rule if it's defined */
-function satisfiesMustInclude(rule) {
-    if ('must_include' in rule && rule['must_include'].length > 0) {
-        core.debug('Iterating over must_include elements');
-        for (const includePath of rule['must_include']) {
-            if (fs_1.default.existsSync(includePath)) {
-                core.info(`Path found in must_include: ${includePath}`);
-                return true;
-            }
-        }
-        return false;
-    }
-    return true;
-}
-exports.satisfiesMustInclude = satisfiesMustInclude;
 
 
 /***/ }),

--- a/src/finder.ts
+++ b/src/finder.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core'
-import fs from 'fs'
 
 import gitP, {SimpleGit} from 'simple-git/promise'
 import {DiffResult} from 'simple-git/typings/response'
@@ -15,10 +14,9 @@ export async function ruleMatchesChange(rule): Promise<boolean> {
   const diff = await getDiff(options)
   core.debug(`Diffing with options ${options}`)
 
-  if (diff.changed > 0 && satisfiesMustInclude(rule)) {
+  if (diff.changed > 0) {
     const diffedFiles = diff.files.map(elem => elem.file)
     core.info(`Changed files: ${diffedFiles}`)
-
     return true
   }
 
@@ -36,22 +34,4 @@ export async function getDiff(extraOptions: string[]): Promise<DiffResult> {
 export function buildOptions(rule: object): string[] {
   const fullPaths: string[] = rule['paths'].map(el => `${ROOT_DIR}/${el}`)
   return fullPaths.length ? ['--', ...fullPaths] : []
-}
-
-/** Processes must_include in the rule if it's defined */
-export function satisfiesMustInclude(rule: object): boolean {
-  if ('must_include' in rule && rule['must_include'].length > 0) {
-    core.debug('Iterating over must_include elements')
-
-    for (const includePath of rule['must_include']) {
-      if (fs.existsSync(includePath)) {
-        core.info(`Path found in must_include: ${includePath}`)
-        return true
-      }
-    }
-
-    return false
-  }
-
-  return true
 }


### PR DESCRIPTION
This PR removes the `must_include` logic to only include options that are natively supported by git diff. This will make things less confusing down the line.